### PR TITLE
Add tor support

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -72,6 +72,14 @@ class Client {
 			return Promise.resolve();
 		}
 		this.status = 1;
+		if (this._options && this._options.proxy && this._options.proxy.port) {
+			this.conn = socks.SocksClient.createConnection(this._options).then(client => {
+				return this.initSocks(client)
+			  });
+  
+			return this.conn;
+		}
+
 		return this.connectSocket(this.conn, this.port, this.host);
 	}
 
@@ -87,6 +95,29 @@ class Client {
 				resolve();
 			});
 		});
+	}
+
+	initSocksProxy(client) {
+		client.socket.setTimeout(TIMEOUT);
+		client.socket.setEncoding('utf8');
+		client.socket.setKeepAlive(true, 0);
+		client.socket.setNoDelay(true);
+		client.socket.on('connect', () => {
+		client.socket.setTimeout(0);
+			this.onConnect();
+		});
+		client.socket.on('close', e => {
+			this.onClose(e);
+		});
+		client.socket.on('data', chunk => {
+			client.socket.setTimeout(0);
+			this.onRecv(chunk);
+		});
+		client.socket.on('error', e => {
+			this.onError(e);
+		});
+
+		return client.socket;
 	}
 
 	close() {
@@ -106,7 +137,14 @@ class Client {
 			const id = ++this.id;
 			const content = util.makeRequest(method, params, id);
 			this.callback_message_queue[id] = util.createPromiseResult(resolve, reject);
-			this.conn.write(content + '\n');
+			if (this._options && this._options.proxy && this._options.proxy.port) {
+				this.conn.then(socket => {
+				  socket.write(content + '\n');
+				  socket.resume();
+				});
+			  } else {
+				this.conn.write(content + '\n');
+			  }
 		});
 	}
 
@@ -122,7 +160,14 @@ class Client {
 				if (secondParam !== undefined) {
 					contents.push(util.makeRequest(method, [param, secondParam], id));
 				} else {
-					contents.push(util.makeRequest(method, [param], id));
+					contents.push(util.makeRequest(method, [param], id));if (this._options && this._options.proxy && this._options.proxy.port) {
+						this.conn.then(socket => {
+						  socket.write(content + '\n');
+						  socket.resume();
+						});
+					  } else {
+						this.conn.write(content + '\n');
+					  }
 				}
 				arguments_far_calls[id] = param;
 			}

--- a/lib/client.js
+++ b/lib/client.js
@@ -3,6 +3,8 @@ let net = require('net');
 let tls = require('tls');
 const TIMEOUT = 5000;
 
+const socks = require('socks');
+
 const TlsSocketWrapper = require('./TlsSocketWrapper.js');
 const EventEmitter = require('events').EventEmitter;
 const util = require('./util');
@@ -74,13 +76,14 @@ class Client {
 		this.status = 1;
 		if (this._options && this._options.proxy && this._options.proxy.port) {
 			this.conn = socks.SocksClient.createConnection(this._options).then(client => {
-				return this.initSocks(client)
+				return this.initSocksProxy(client)
 			  });
   
-			return this.conn;
+			  return this.conn;
+		} else {
+			return this.connectSocket(this.conn, this.port, this.host);
 		}
 
-		return this.connectSocket(this.conn, this.port, this.host);
 	}
 
 	connectSocket(conn, port, host) {
@@ -160,21 +163,21 @@ class Client {
 				if (secondParam !== undefined) {
 					contents.push(util.makeRequest(method, [param, secondParam], id));
 				} else {
-					contents.push(util.makeRequest(method, [param], id));if (this._options && this._options.proxy && this._options.proxy.port) {
-						this.conn.then(socket => {
-						  socket.write(content + '\n');
-						  socket.resume();
-						});
-					  } else {
-						this.conn.write(content + '\n');
-					  }
+					contents.push(util.makeRequest(method, [param], id));
 				}
 				arguments_far_calls[id] = param;
 			}
 			const content = '[' + contents.join(',') + ']';
 			this.callback_message_queue[this.id] = util.createPromiseResultBatch(resolve, reject, arguments_far_calls);
-			// callback will exist only for max id
-			this.conn.write(content + '\n');
+			if (this._options && this._options.proxy && this._options.proxy.port) {
+				this.conn.then(socket => {
+				  socket.write(content + '\n');
+				  socket.resume();
+				});
+			  } else {
+				  // callback will exist only for max id
+				  this.conn.write(content + '\n');
+			  }
 		});
 	}
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -75,7 +75,7 @@ class Client {
 		}
 		this.status = 1;
 		if (this._options && this._options.proxy && this._options.proxy.port) {
-			this.conn = socks.SocksClient.createConnection(this._options).then(client => {
+			this.conn = socks.SocksClient.createConnection({command: "connect", destination: {port: this.port, host: this.host  }, ...this._options}).then(client => {
 				return this.initSocksProxy(client)
 			  });
   

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
-	"dependencies": {},
+	"dependencies": {
+		"socks": "^2.6.1"
+	},
 	"devDependencies": {},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
This adds the ability to connect to Electrum over a Tor connection:

```
const client = new ElectrumClient(50001, "myonionaddress.onion", "tcp", {
    proxy: {
      host: "127.0.0.1",
      port: 9050,
      type: 5,
    },
  });
```

Based on a similar PR made on BlueWallet's version of this client: https://github.com/BlueWallet/rn-electrum-client/pull/4